### PR TITLE
chore(release): rename package to @adfinis/eslint-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @adfinis-sygroup/eslint-config
+# @adfinis/eslint-config
 
 This package contains our internally used eslint config.
 
@@ -7,7 +7,7 @@ This package contains our internally used eslint config.
 To install this package, simply run
 
 ```bash
-yarn add -D @adfinis-sygroup/eslint-config \
+yarn add -D @adfinis/eslint-config \
             eslint \
             eslint-config-prettier \
             eslint-plugin-prettier \
@@ -18,7 +18,7 @@ Then add the following to your `.eslintrc.js`
 
 ```js
 module.exports = {
-  extends: "@adfinis-sygroup/eslint-config",
+  extends: "@adfinis/eslint-config",
 };
 ```
 
@@ -28,7 +28,7 @@ If you are using it in an ember app or addon you can use the config for
 ember:
 
 ```bash
-yarn add -D @adfinis-sygroup/eslint-config \
+yarn add -D @adfinis/eslint-config \
             @babel/core \
             @babel/eslint-parser \
             eslint \
@@ -45,7 +45,7 @@ For an app replace your `.eslintrc.js` with this:
 
 ```js
 module.exports = {
-  extends: "@adfinis-sygroup/eslint-config/ember-app",
+  extends: "@adfinis/eslint-config/ember-app",
 };
 ```
 
@@ -53,7 +53,7 @@ Or for an addon replace your `.eslintrc.js` with this:
 
 ```js
 module.exports = {
-  extends: "@adfinis-sygroup/eslint-config/ember-addon",
+  extends: "@adfinis/eslint-config/ember-addon",
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@adfinis-sygroup/eslint-config",
+  "name": "@adfinis/eslint-config",
   "version": "1.6.1",
   "description": "Adfinis' ESlint config, following our coding guidelines",
   "main": "index.js",
@@ -9,21 +9,21 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adfinis-sygroup/eslint-config.git"
+    "url": "git+https://github.com/adfinis/eslint-config.git"
   },
   "keywords": [
     "eslint",
     "eslintconfig",
-    "adfinis-sygroup",
+    "adfinis",
     "javascript",
     "styleguide"
   ],
   "author": "Adfinis AG <info@adfinis.com>",
   "license": "LGPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/adfinis-sygroup/eslint-config/issues"
+    "url": "https://github.com/adfinis/eslint-config/issues"
   },
-  "homepage": "https://github.com/adfinis-sygroup/eslint-config#readme",
+  "homepage": "https://github.com/adfinis/eslint-config#readme",
   "peerDependencies": {
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.21.3",


### PR DESCRIPTION
BREAKING CHANGE: This package is now being released under the name `@adfinis/eslint-config` instead of `@adfinis-sygroup/eslint-config`.

Resolves #321